### PR TITLE
Make compile target depend on compile-native

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -258,7 +258,7 @@
 
   </target>
 
-  <target name="compile" depends="compile-java,buildinfo" 
+  <target name="compile" depends="compile-java,compile-native,buildinfo" 
           description="Compile all">
   </target>
 


### PR DESCRIPTION
The description says "Compile all" so I think this should be the right place for it.

tar -> package -> compile: So an "ant tar" build now builds everything.
